### PR TITLE
Add rules for helper functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,18 @@ module.exports = {
         'shared-node-browser': true,
         jest: true,
       },
+      rules: {
+        'jest/no-standalone-expect': [
+          'error',
+          { 'additionalTestBlockFunctions':
+            ['test.jestPlaywrightDebug',
+              'it.jestPlaywrightDebug',
+              'test.jestPlaywrightSkip',
+              'it.jestPlaywrightSkip',
+              'test.jestPlaywrightConfig',
+              'it.jestPlaywrightConfig']
+          }
+      ]},
       globals: {
         browserName: true,
         deviceName: true,


### PR DESCRIPTION
Will fix these kind of errors:
`Expect must be inside of a test block. eslintjest/no-standalone-expect`

https://github.com/playwright-community/jest-playwright/issues/216#issuecomment-663645370