### PR TITLE
Add missing eslint peer

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,5 +18,8 @@
   },
   "dependencies": {
     "eslint-plugin-jest": "^24.3.6"
+  },
+  "peerDependencies": {
+    "eslint": ">=5"
   }
 }


### PR DESCRIPTION
Yarn displays a warning when install `eslint-plugin-jest-playwright` since it depends on `eslint-plugin-jest` which has a peer on `eslint` which isn't expressed in the manifest for `eslint-plugin-jest-playwright`.

This PR updates the manifest to include a peer on eslint.