### PR TITLE
fix: explicit jest plugin dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Add `plugin:jest-playwright/recommended` to your extends ESLint configuration. F
 
 ```json
 {
-  "extends": ["plugin:jest-playwright/recommended"],
+  "extends": ["plugin:jest-playwright/recommended"]
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ Add `plugin:jest-playwright/recommended` to your extends ESLint configuration. F
 ```json
 {
   "extends": ["plugin:jest-playwright/recommended"],
-  "plugins": ["jest-playwright"]
 }
 ```
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@ const missingPlaywrightAwait = require("./rules/missing-playwright-await");
 module.exports = {
   configs: {
     recommended: {
+      plugins: ['jest'],
       env: {
         "shared-node-browser": true,
         jest: true,

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,7 @@ const missingPlaywrightAwait = require("./rules/missing-playwright-await");
 module.exports = {
   configs: {
     recommended: {
-      plugins: ['jest'],
+      plugins: ['jest', 'jest-playwright'],
       env: {
         "shared-node-browser": true,
         jest: true,


### PR DESCRIPTION
Hello 👋 

I am getting a lot of errors after upgrading to 0.3.2

```
Definition for rule 'jest/no-standalone-expect' was not found  jest/no-standalone-expect
```

Because I don't have eslint-plugin-jest as an explicit plugin in my config :)